### PR TITLE
Restart strategy for rms_node_manager/rms_claster_manager sups

### DIFF
--- a/src/rms_cluster_manager.erl
+++ b/src/rms_cluster_manager.erl
@@ -147,7 +147,7 @@ apply_offer(OfferHelper, NodeData) ->
 %% supervisor callback function.
 
 -spec init({}) ->
-    {ok, {{supervisor:strategy(), 10, 10}, [supervisor:child_spec()]}}.
+    {ok, {{supervisor:strategy(), 1, 1}, [supervisor:child_spec()]}}.
 init({}) ->
     Specs = [cluster_spec(Key) ||
              {Key, _Cluster} <- rms_metadata:get_clusters()],

--- a/src/rms_node_manager.erl
+++ b/src/rms_node_manager.erl
@@ -344,7 +344,7 @@ apply_reserved_offer(NodeKey, OfferHelper,
 %% supervisor callback function.
 
 -spec init({}) ->
-    {ok, {{supervisor:strategy(), 10, 10}, [supervisor:child_spec()]}}.
+    {ok, {{supervisor:strategy(), 1, 1}, [supervisor:child_spec()]}}.
 init({}) ->
     Specs = [node_spec(Key, proplists:get_value(cluster_key, Node)) ||
              {Key, Node} <- rms_metadata:get_nodes()],


### PR DESCRIPTION
I think we should crash the whole app in case of any (node or claster) process crash.  
