### PR TITLE
Allow converting floats as integers

### DIFF
--- a/src/rms_config.erl
+++ b/src/rms_config.erl
@@ -121,6 +121,12 @@ get_value(Key, Default, Type) ->
 %% Internal functions.
 
 -spec convert_value(term(), atom()) -> term().
+convert_value(Value, number) when is_list(Value) ->
+    try
+        list_to_float(Value)
+    catch 
+        error:badarg -> list_to_integer(Value)
+    end;
 convert_value(Value, integer) when is_list(Value) ->
     list_to_integer(Value);
 convert_value(Value, float) when is_list(Value) ->

--- a/src/rms_sup.erl
+++ b/src/rms_sup.erl
@@ -59,7 +59,7 @@ init([]) ->
     FrameworkHostname = rms_config:framework_hostname(),
     FrameworkPrincipal = rms_config:get_value(principal, "riak", string),
     FrameworkFailoverTimeout =
-        rms_config:get_value(failover_timeout, 10000.0, float),
+        rms_config:get_value(failover_timeout, 10000.0, number),
     FrameworkWebUIURL = rms_config:webui_url(),
     Constraints = rms_config:constraints(),
 
@@ -67,12 +67,12 @@ init([]) ->
     _FrameworkAuthProvider = rms_config:get_value(provider, "", string),
     _FrameworkAuthSecret = rms_config:get_value(secret_file, "", string),
 
-    NodeCpus = rms_config:get_value(node_cpus, 0.5, float),
-    NodeMem = rms_config:get_value(node_mem, 1024.0, float),
-    NodeDisk = rms_config:get_value(node_disk, 4000.0, float),
+    NodeCpus = rms_config:get_value(node_cpus, 0.5, number),
+    NodeMem = rms_config:get_value(node_mem, 1024.0, number),
+    NodeDisk = rms_config:get_value(node_disk, 4000.0, number),
 
-    ExecutorCpus = rms_config:get_value(executor_cpus, 0.1, float),
-    ExecutorMem = rms_config:get_value(executor_mem, 512.0, float),
+    ExecutorCpus = rms_config:get_value(executor_cpus, 0.1, number),
+    ExecutorMem = rms_config:get_value(executor_mem, 512.0, number),
 
     ArtifactUrls = rms_config:artifact_urls(),
 


### PR DESCRIPTION
Floats ending in `.0` tend to get truncated to an integer, which `erlang:list_to_float/1` then throws a badarg on.

This change adds `rms_config:convert_value(V, number)` which attempts to parse a float, then an int.

NB There are some fields that must be an integer (e.g. port nrs) - I've left these as integers.

I've tested this locally on a [dcos-vagrant](https://github.com/dcos/dcos-vagrant) cluster and it looks to work OK.