### PR TITLE
unique executor_id

### DIFF
--- a/src/rms_cluster_manager.erl
+++ b/src/rms_cluster_manager.erl
@@ -191,7 +191,9 @@ executors_to_shutdown([NodeKey|Rest], Accum) ->
   case rms_node_manager:node_can_be_shutdown(NodeKey) of
       {ok, true} ->
           {ok, AgentIdValue} = rms_node_manager:get_node_agent_id_value(NodeKey),
-          executors_to_shutdown(Rest, [{NodeKey, AgentIdValue}|Accum]);
+          {ok, PersistenceId} = rms_node_manager:get_node_persistence_id(NodeKey),
+          ExecutorId = NodeKey ++ "-" ++ PersistenceId,
+          executors_to_shutdown(Rest, [{ExecutorId, AgentIdValue}|Accum]);
       {ok, false} ->
           executors_to_shutdown(Rest, Accum)
   end.

--- a/src/rms_node_manager.erl
+++ b/src/rms_node_manager.erl
@@ -403,7 +403,10 @@ apply_reserved_offer(NodeKey, OfferHelper) ->
                                 {<<"DisterlPort">>,            DisterlPort}],
                     TaskDataBin = iolist_to_binary(mochijson2:encode(TaskData)),
 
-                    ExecutorId = erl_mesos_utils:executor_id(NodeKey ++ "-" ++ PersistenceId),
+                    % Tack a new UUID onto ExecutorId - this way we don't clash with previous instances of this same node
+                    % in places like mesos web-ui
+                    % NB This is used as the executor's nodename so must be a valid erlang nodename
+                    ExecutorId = erl_mesos_utils:executor_id(NodeKey ++ "-" ++ uuid:to_string(uuid:uuid4())),
 
                     Source = Name,
                     ExecutorInfo =

--- a/src/rms_node_manager.erl
+++ b/src/rms_node_manager.erl
@@ -403,7 +403,7 @@ apply_reserved_offer(NodeKey, OfferHelper) ->
                                 {<<"DisterlPort">>,            DisterlPort}],
                     TaskDataBin = iolist_to_binary(mochijson2:encode(TaskData)),
 
-                    ExecutorId = erl_mesos_utils:executor_id(NodeKey),
+                    ExecutorId = erl_mesos_utils:executor_id(NodeKey ++ "-" ++ PersistenceId),
 
                     Source = Name,
                     ExecutorInfo =

--- a/src/rms_scheduler.erl
+++ b/src/rms_scheduler.erl
@@ -419,16 +419,15 @@ may_be_delete_scheduler(_Message) ->
     {ok, state()} | {stop, state()}.
 shutdown_executors(_, [], State) ->
     {ok, State};
-shutdown_executors(SchedulerInfo, [{NodeKey, AgentIdValue}|Rest], State) ->
+shutdown_executors(SchedulerInfo, [{ExecutorValue, AgentIdValue}|Rest], State) ->
     AgentId = erl_mesos_utils:agent_id(AgentIdValue),
-    ExecutorId = erl_mesos_utils:executor_id(NodeKey),
-    _TaskId = erl_mesos_utils:task_id(NodeKey),
-    lager:info("Finishing ~p.", [NodeKey]),
+    ExecutorId = erl_mesos_utils:executor_id(ExecutorValue),
+    lager:info("Finishing ~p.", [ExecutorValue]),
     case call(message, 
               [SchedulerInfo, AgentId, 
                ExecutorId, <<"finish">>], State) of
         {ok, S1} ->
-            lager:info("Told ~p to finish.", [NodeKey]),
+            lager:info("Told ~p to finish.", [ExecutorValue]),
             shutdown_executors(SchedulerInfo, Rest, S1);
         R -> 
             lager:info("Error telling node to finish: ~p.", [R]),


### PR DESCRIPTION
When starting a new node, or restarting a failed/finished node, we always it the executor_id of `$nodekey` (e.g. `riak-default-3`). This led to some subtle issues in the mesos ui, in that you could not access the sandbox of failed/finished nodes, because the links now pointed to the sandbox of the most recent instance of that node.

With this change, we tack a random UUID onto the executor_id every time, making it more unique in mesos.