### PR TITLE
Rename 'version' file to 'scheduler-version'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,10 +83,10 @@ tarball: clean-deps retarball
 retarball: rel
 	echo "Creating packages/"$(PKGNAME)
 	mkdir -p packages
-	echo "$(GIT_REF)" > rel/version
-	echo "$(GIT_TAG_ISH)" >> rel/version
-	tar -C rel -czf $(PKGNAME) version $(RELDIR)/
-	rm rel/version
+	echo "$(GIT_REF)" > rel/scheduler-version
+	echo "$(GIT_TAG_ISH)" >> rel/scheduler-version
+	tar -C rel -czf $(PKGNAME) scheduler-version $(RELDIR)/
+	rm rel/scheduler-version
 	mv $(PKGNAME) packages/
 	cd packages && $(SHASUM) $(PKGNAME) > $(PKGNAME).sha
 	cd packages && echo "$(DOWNLOAD_BASE)" > remote.txt


### PR DESCRIPTION
Because of how marathon/mesos actually extract all the archives, this version file actually gets clobbered by the identically named file in the executor archive. This prevents that.

Ultimately I think this file can probably go away now that our archives are more accurately named, although it would be useful in local development to have the `-dirty` flag for a dirty working tree.