### PR TITLE
Fix single node remove

### DIFF
--- a/src/rms_node.erl
+++ b/src/rms_node.erl
@@ -599,16 +599,13 @@ delete_reply_stop({State, #node{key = Key} = Node}, Reply, Reason) ->
     end.
 
 leave(State, #node{cluster_key = Cluster, key = Key} = Node, Timeout) ->
-    Node1 = Node#node{hostname = "",
-                      agent_id_value = "",
-                      persistence_id = ""},
     case rms_cluster_manager:leave(Cluster, Key) of
         ok ->
             lager:info("~p left cluster ~p successfully.", [Key, Cluster]),
-            update_and_reply({State, Node}, {leaving, Node1}, Timeout);
+            update_and_reply({State, Node}, {leaving, Node}, Timeout);
         {error, no_suitable_nodes} ->
             lager:info("~p was unable to leave cluster ~p because no nodes were available to leave from.", [Key, Cluster]),
-            update_and_reply({State, Node}, {shutting_down, Node1}, Timeout);
+            update_and_reply({State, Node}, {shutting_down, Node}, Timeout);
         {error, Reason} ->
             lager:warning("~p was unable to leave cluster ~p because ~p.", [Key, Cluster, Reason]),
             {reply, {error, Reason}, State, Node}

--- a/src/rms_node.erl
+++ b/src/rms_node.erl
@@ -483,6 +483,10 @@ leaving(can_be_shutdown, _From, Node) ->
     {reply, {ok, false}, leaving, Node};
 leaving(can_be_scheduled, _From, Node) ->
     {reply, {ok, false}, leaving, Node};
+leaving({destroy, false}, _From, Node) ->
+    {reply, ok, leaving, Node};
+leaving({destroy, true}, _From, Node) ->
+    update_and_reply({leaving, Node}, {shutting_down, Node});
 leaving(_Event, _From, Node) ->
     {reply, {error, unhandled_event}, leaving, Node}.
 


### PR DESCRIPTION
This PR fixes a couple of bugs around the last node leaving a cluster peacefully:

 - A node stuck in `leaving` state could not handle a subsequent `cluster destroy`
 - Upon entering `leaving` state, the scheduler could lose contact with the executor, rendering it unable to tell it to `finish` correctly
 - The last node in a cluster does not need to `leave` a cluster at all

NB A subsequent `node remove` on an already leaving node will be a no-op. To forcibly stop that node, use `node remove --force` or `cluster destroy`