### PR TITLE
Improve node management

### DIFF
--- a/rel/sys.config
+++ b/rel/sys.config
@@ -25,6 +25,7 @@
    {crash_log_msg_size,65536},
    {handlers,
     [
+     {lager_console_backend, debug},
      {lager_file_backend,
       [
        {file,"./log/console.log"},

--- a/src/riak_explorer_client.erl
+++ b/src/riak_explorer_client.erl
@@ -24,9 +24,9 @@
 -spec node_key_from_cluster(string()) -> {error, not_found} | string().
 node_key_from_cluster(ClusterKey) ->
     case rms_node_manager:get_running_node_keys(ClusterKey) of
-        [N|_] -> 
+        [N|_] ->
             N;
-        _ -> 
+        _ ->
             {error, not_found}
     end.
 

--- a/src/rms_cluster_manager.erl
+++ b/src/rms_cluster_manager.erl
@@ -294,10 +294,11 @@ schedule_node(NodeKey, NodeKeys, OfferHelper) ->
         false ->
             %% New Node
             case rms_offer_helper:can_fit_constraints(OfferHelper) of
-                true ->
+                ok ->
                     apply_unreserved_offer(NodeKey, NodeKeys,
                                            OfferHelper);
-                false ->
+                {error, Reason} ->
+                    lager:warning("Node (~s) unscheduled, constraint violated: ~p", [NodeKey, Reason]),
                     apply_offer(NodeKeys, OfferHelper)
             end
     end.

--- a/src/rms_cluster_manager.erl
+++ b/src/rms_cluster_manager.erl
@@ -309,19 +309,19 @@ schedule_node(NodeKey, NodeKeys, OfferHelper) ->
 apply_unreserved_offer(NodeKey, NodeKeys, OfferHelper) ->
     case rms_node_manager:apply_unreserved_offer(NodeKey, OfferHelper) of
         {ok, OfferHelper1} ->
-            lager:info("Found new offer for node. "
-                       "Node key: ~s. "
-                       "Offer id: ~s. "
-                       "Offer resources: ~p.",
+            lager:info("Found new offer for node."
+                       " Node key: ~s."
+                       " Offer id: ~s."
+                       " Offer resources: ~p.",
                        [NodeKey,
                         rms_offer_helper:get_offer_id_value(OfferHelper1),
                         rms_offer_helper:resources_to_list(OfferHelper1)]),
             OfferHelper1;
         {error, Reason} ->
-            lager:warning("Applying of unreserved resources error. "
-                          "Node key: ~s. "
-                          "Offer id: ~s. "
-                          "Error reason: ~p.",
+            lager:warning("Unable to apply unreserved resources."
+                          " Node key: ~s."
+                          " Offer id: ~s."
+                          " Error reason: ~p.",
                           [NodeKey,
                            rms_offer_helper:get_offer_id_value(OfferHelper),
                            Reason]),

--- a/src/rms_cluster_manager.erl
+++ b/src/rms_cluster_manager.erl
@@ -238,8 +238,17 @@ apply_offer(OfferHelper) ->
         N when length(N) > 0 ->
             OfferHelper2;
         _ ->
-            NodeKeys = rms_node_manager:get_node_keys(),
-            OfferHelper3 = apply_offer(NodeKeys, OfferHelper2),
+            NodeKeys = rms_node_manager:get_unscheduled_node_keys(),
+            ReservedNodes = lists:filter(fun rms_node_manager:node_has_reservation/1, NodeKeys),
+            UnreservedNodes = NodeKeys -- ReservedNodes,
+            OfferHelper3 =
+                case {rms_offer_helper:has_reserved_resources(OfferHelper2),
+                        rms_offer_helper:has_unreserved_resources(OfferHelper2)} of
+                    {true, _} -> % Apply reserved resources to nodes with a reservation
+                        apply_reserved_resources(ReservedNodes, OfferHelper2);
+                    {_, true} -> % Apply unreserved resources
+                        apply_unreserved_resources(UnreservedNodes, OfferHelper2)
+                end,
             case rms_offer_helper:should_unreserve_resources(OfferHelper3) of
                 true ->
                     unreserve_volumes(unreserve_resources(OfferHelper3));
@@ -259,49 +268,80 @@ init({}) ->
 
 %% Internal functions.
 
--spec apply_offer([rms_node:key()],
-                  rms_offer_helper:offer_helper()) ->
-                         rms_offer_helper:offer_helper().
-apply_offer([NodeKey | NodeKeys], OfferHelper) ->
-    %% One launch at a time for now
-    case rms_offer_helper:has_tasks_to_launch(OfferHelper) of
-        true ->
-            OfferHelper;
-        false ->
-            case rms_node_manager:node_can_be_scheduled(NodeKey) of
-                % TODO How do we clean up the node keys here?
-                {error, shutdown} ->
-                    apply_offer(NodeKeys, OfferHelper);
-                {ok, true} ->
-                    schedule_node(NodeKey, NodeKeys,
-                                  OfferHelper);
-                {ok, false} ->
-                    apply_offer(NodeKeys, OfferHelper)
-            end
-    end;
-apply_offer([], OfferHelper) ->
-    OfferHelper.
-
--spec schedule_node(rms_node:key(), [rms_node:key()],
-                    rms_offer_helper:offer_helper()) ->
+-spec apply_reserved_resources(list(rms_node:key()), rms_offer_helper:offer_helper()) ->
     rms_offer_helper:offer_helper().
-schedule_node(NodeKey, NodeKeys, OfferHelper) ->
-    case rms_node_manager:node_has_reservation(NodeKey) of
+apply_reserved_resources([NodeKey | NodeKeys], OfferHelper) ->
+    case rms_offer_helper:has_tasks_to_launch(OfferHelper) of
+        true  -> OfferHelper;
+        false -> apply_reserved_offer(NodeKey, NodeKeys, OfferHelper)
+    end;
+apply_reserved_resources([], OfferHelper) -> OfferHelper.
+
+-spec apply_reserved_offer(rms_node:key(), [rms_node:key()],
+                           rms_offer_helper:offer_helper()) ->
+    rms_offer_helper:offer_helper().
+apply_reserved_offer(NodeKey, NodeKeys, OfferHelper) ->
+    {ok, PersistenceId} = rms_node_manager:get_node_persistence_id(NodeKey),
+    OfferIdValue = rms_offer_helper:get_offer_id_value(OfferHelper),
+    case rms_offer_helper:has_persistence_id(PersistenceId, OfferHelper) of
         true ->
-            %% Apply reserved resources.
-            apply_reserved_offer(NodeKey, NodeKeys,
-                                 OfferHelper);
-        false ->
-            %% New Node
-            case rms_offer_helper:can_fit_constraints(OfferHelper) of
-                ok ->
-                    apply_unreserved_offer(NodeKey, NodeKeys,
-                                           OfferHelper);
+            %% Found reserved resources for node.
+            %% Persistence id matches.
+            %% Try to launch the node.
+            case rms_node_manager:apply_reserved_offer(NodeKey, OfferHelper) of
+                {ok, OfferHelper1} ->
+                    ResourcesList =
+                        rms_offer_helper:resources_to_list(OfferHelper),
+                    lager:info("New node added for scheduling. "
+                               "Node key: ~s. "
+                               "Persistence id: ~s. "
+                               "Offer id: ~s. "
+                               "Offer resources: ~p.",
+                               [NodeKey, PersistenceId, OfferIdValue,
+                                ResourcesList]),
+                    OfferHelper1;
+                {error, {not_enough_resources, Missing}} ->
+                    OfferHelper1 =
+                        rms_offer_helper:set_sufficient_resources(false, OfferHelper),
+                    lager:warning("Error scheduling node."
+                                  " Offer has insufficient resources for this node."
+                                  %% TODO Do we really need to try other nodes? Do we not guarantee that all nodes in all our clusters require the same resources?
+                                  " Trying other nodes."
+                                  " Node key: ~s."
+                                  " Missing resources: ~p."
+                                  " Persistence id: ~s."
+                                  " Offer id: ~s.",
+                                  [NodeKey, Missing, PersistenceId, OfferIdValue]),
+                    apply_reserved_resources(NodeKeys, OfferHelper1);
                 {error, Reason} ->
-                    lager:warning("Node (~s) unscheduled, constraint violated: ~p", [NodeKey, Reason]),
-                    apply_offer(NodeKeys, OfferHelper)
-            end
+                    lager:warning("Error scheduling node."
+                                  " Node key: ~s."
+                                  " Persistence id: ~s."
+                                  " Offer id: ~s."
+                                  " Error reason: ~p.",
+                                  [NodeKey, PersistenceId, OfferIdValue,
+                                   Reason]),
+                    apply_reserved_resources(NodeKeys, OfferHelper)
+            end;
+        false ->
+            lager:debug("Not scheduling node on this offer: persistence_id mismatch."
+                        " Node key: ~s."
+                        " Node persistence id: ~s."
+                        " Offer id: ~s.",
+                        [NodeKey, PersistenceId, OfferIdValue]),
+            apply_reserved_resources(NodeKeys, OfferHelper)
     end.
+
+-spec apply_unreserved_resources(list(rms_node:key()), rms_offer_helper:offer_helper()) ->
+    rms_offer_helper:offer_helper().
+apply_unreserved_resources([NodeKey | NodeKeys], OfferHelper) ->
+    case rms_offer_helper:can_fit_constraints(OfferHelper) of
+        ok -> apply_unreserved_offer(NodeKey, NodeKeys, OfferHelper);
+        {error, Reason} ->
+            lager:warning("Node (~s) unscheduled, constraint violated: ~p", [NodeKey, Reason]),
+            apply_unreserved_resources(NodeKeys, OfferHelper)
+    end;
+apply_unreserved_resources([], OfferHelper) -> OfferHelper.
 
 -spec apply_unreserved_offer(rms_node:key(), [rms_node:key()],
                              rms_offer_helper:offer_helper()) ->
@@ -325,59 +365,7 @@ apply_unreserved_offer(NodeKey, NodeKeys, OfferHelper) ->
                           [NodeKey,
                            rms_offer_helper:get_offer_id_value(OfferHelper),
                            Reason]),
-            apply_offer(NodeKeys, OfferHelper)
-    end.
-
--spec apply_reserved_offer(rms_node:key(), [rms_node:key()],
-                           rms_offer_helper:offer_helper()) ->
-    rms_offer_helper:offer_helper().
-apply_reserved_offer(NodeKey, NodeKeys, OfferHelper) ->
-    {ok, PersistenceId} = rms_node_manager:get_node_persistence_id(NodeKey),
-    OfferIdValue = rms_offer_helper:get_offer_id_value(OfferHelper),
-    case rms_offer_helper:has_persistence_id(PersistenceId, OfferHelper) of
-        true ->
-            %% Found reserved resources for node.
-            %% Persistence id matches.
-            %% Try to launch the node.
-            case rms_node_manager:apply_reserved_offer(NodeKey, OfferHelper) of
-                {ok, OfferHelper1} ->
-                    ResourcesList =
-                        rms_offer_helper:resources_to_list(OfferHelper),
-                    lager:info("New node added for scheduling. "
-                               "Node has persistence id. "
-                               "Node key: ~s. "
-                               "Persistence id: ~s. "
-                               "Offer id: ~s. "
-                               "Offer resources: ~p.",
-                               [NodeKey, PersistenceId, OfferIdValue,
-                                ResourcesList]),
-                    OfferHelper1;
-                {error, not_enough_resources} ->
-                    OfferHelper1 =
-                        rms_offer_helper:set_sufficient_resources(false, OfferHelper),
-                    lager:warning("Adding node for scheduling error. "
-                                  "Node has persistence id. "
-                                  "Offer did not have sufficient resources for this node. "
-                                  %% TODO Do we really need to try other nodes? Do we not guarantee that all nodes in all our clusters require the same resources?
-                                  "Trying other nodes. "
-                                  "Node key: ~s. "
-                                  "Persistence id: ~s. "
-                                  "Offer id: ~s. ",
-                                  [NodeKey, PersistenceId, OfferIdValue]),
-                    apply_offer(NodeKeys, OfferHelper1);
-                {error, Reason} ->
-                    lager:warning("Adding node for scheduling error. "
-                                  "Node has persistence id. "
-                                  "Node key: ~s. "
-                                  "Persistence id: ~s. "
-                                  "Offer id: ~s. "
-                                  "Error reason: ~p.",
-                                  [NodeKey, PersistenceId, OfferIdValue,
-                                   Reason]),
-                    apply_offer(NodeKeys, OfferHelper)
-            end;
-        false ->
-            apply_offer(NodeKeys, OfferHelper)
+            apply_unreserved_resources(NodeKeys, OfferHelper)
     end.
 
 -spec unreserve_resources(rms_offer_helper:offer_helper()) ->

--- a/src/rms_cluster_manager.erl
+++ b/src/rms_cluster_manager.erl
@@ -353,7 +353,7 @@ apply_reserved_offer(NodeKey, NodeKeys, OfferHelper) ->
                                 ResourcesList]),
                     OfferHelper1;
                 {error, not_enough_resources} ->
-                    OfferHelper1 = 
+                    OfferHelper1 =
                         rms_offer_helper:set_sufficient_resources(false, OfferHelper),
                     lager:warning("Adding node for scheduling error. "
                                   "Node has persistence id. "

--- a/src/rms_cluster_manager.erl
+++ b/src/rms_cluster_manager.erl
@@ -208,7 +208,7 @@ maybe_join(Key, NodeKey) ->
 
 -spec leave(rms_cluster:key(), rms_node:key()) -> ok | {error, term()}.
 leave(Key, NodeKey) ->
-    case rms_node_manager:get_node_keys(Key) of
+    case rms_node_manager:get_node_keys(Key, started) of
         %% If this is the only node in the cluster, there's no point
         %% talking to riak-explorer: just signal that there are no other
         %% nodes to leave from
@@ -358,6 +358,7 @@ apply_reserved_offer(NodeKey, NodeKeys, OfferHelper) ->
                     lager:warning("Adding node for scheduling error. "
                                   "Node has persistence id. "
                                   "Offer did not have sufficient resources for this node. "
+                                  %% TODO Do we really need to try other nodes? Do we not guarantee that all nodes in all our clusters require the same resources?
                                   "Trying other nodes. "
                                   "Node key: ~s. "
                                   "Persistence id: ~s. "

--- a/src/rms_node.erl
+++ b/src/rms_node.erl
@@ -343,7 +343,8 @@ requested(can_be_scheduled, _From, Node) ->
 requested(can_be_shutdown, _From, Node) ->
     {reply, {ok, false}, requested, Node};
 requested({destroy, _}, _From, Node) ->
-    update_and_reply({requested, Node}, {shutting_down, Node});
+% We can simply go away because nothing has happened yet
+    delete_reply_stop({requested, Node}, ok, normal);
 requested(_Event, _From, Node) ->
     {reply, {error, unhandled_event}, requested, Node}.
 

--- a/src/rms_node_manager.erl
+++ b/src/rms_node_manager.erl
@@ -31,6 +31,7 @@
          get_node_attributes/0,
          get_node_keys/0,
          get_unreconciled_node_keys/0,
+         get_unscheduled_node_keys/0,
          get_node_keys/1,
          get_node_keys/2,
          get_node_names/1,
@@ -83,6 +84,10 @@ get_node_keys() ->
 get_unreconciled_node_keys() ->
     [Key || Key <- get_node_keys(),
             true =:= node_needs_to_be_reconciled(Key)].
+
+-spec get_unscheduled_node_keys() -> [rms_node:key()].
+get_unscheduled_node_keys() ->
+    [Key || Key <- get_node_keys(), {ok, true} =:= node_can_be_scheduled(Key)].
 
 -spec get_node_keys(rms_cluster:key()) -> [rms_node:key()].
 get_node_keys(ClusterKey) ->

--- a/src/rms_node_manager.erl
+++ b/src/rms_node_manager.erl
@@ -37,6 +37,7 @@
          get_active_node_keys/1,
          get_running_node_keys/1,
          get_node/1,
+         get_node_state/1,
          get_node_cluster_key/1,
          get_node_hostname/1,
          get_node_http_port/1,
@@ -117,6 +118,11 @@ get_running_node_keys(ClusterKey) ->
                       {ok, rms_metadata:node_state()} | {error, term()}.
 get_node(Key) ->
     rms_node:get(Key).
+
+-spec get_node_state(rms_node:key()) ->
+    {ok, rms_node:node_state()} | {error, term()}.
+get_node_state(Key) ->
+    rms_node:get_field_value(status, Key).
 
 -spec get_node_cluster_key(rms_node:key()) ->
                                   {ok, rms_cluster:key()} | {error, term()}.

--- a/src/rms_node_manager.erl
+++ b/src/rms_node_manager.erl
@@ -32,6 +32,7 @@
          get_node_keys/0,
          get_unreconciled_node_keys/0,
          get_node_keys/1,
+         get_node_keys/2,
          get_node_names/1,
          get_active_node_keys/1,
          get_running_node_keys/1,
@@ -86,6 +87,13 @@ get_unreconciled_node_keys() ->
 get_node_keys(ClusterKey) ->
     [Key || {Key, Node} <- rms_metadata:get_nodes(),
             ClusterKey =:= proplists:get_value(cluster_key, Node)].
+
+-spec get_node_keys(rms_cluster:key(), State :: atom()) ->
+    [rms_node:key()].
+get_node_keys(ClusterKey, State) when is_atom(State) ->
+    [ Key || {Key, Node} <- rms_metadata:get_nodes(),
+             ClusterKey =:= proplists:get_value(cluster_key, Node),
+             State =:= proplists:get_value(status, Node)].
 
 -spec get_node_names(rms_cluster:key()) -> [atom()].
 get_node_names(ClusterKey) ->

--- a/src/rms_offer_helper.erl
+++ b/src/rms_offer_helper.erl
@@ -115,15 +115,15 @@ new(#'Offer'{resources = Resources, attributes = OfferAttributes} = Offer) ->
                   attributes = Attributes}.
 
 -spec set_node_hostnames(hostnames(), offer_helper()) -> offer_helper().
-set_node_hostnames(NodeHostnames, OfferHelper) -> 
+set_node_hostnames(NodeHostnames, OfferHelper) ->
     OfferHelper#offer_helper{node_hostnames=NodeHostnames}.
 
 -spec set_node_attributes(attributes_group(), offer_helper()) -> offer_helper().
-set_node_attributes(NodeAttributes, OfferHelper) -> 
+set_node_attributes(NodeAttributes, OfferHelper) ->
     OfferHelper#offer_helper{node_attributes=NodeAttributes}.
 
 -spec set_constraints(constraints(), offer_helper()) -> offer_helper().
-set_constraints(Constraints, OfferHelper) -> 
+set_constraints(Constraints, OfferHelper) ->
     OfferHelper#offer_helper{constraints=Constraints}.
 
 -spec can_fit_constraints(offer_helper()) -> boolean().
@@ -133,11 +133,11 @@ can_fit_constraints(#offer_helper{
                        node_attributes=NodeAttributes}=OfferHelper) ->
     can_fit_constraints(Constraints, NodeHostnames, NodeAttributes, OfferHelper).
 
--spec can_fit_constraints(constraints(), hostnames(), attributes_group(), 
+-spec can_fit_constraints(constraints(), hostnames(), attributes_group(),
                           offer_helper()) -> ok | {error, Reason :: term()}.
 can_fit_constraints([], _, _, _) ->
     ok;
-can_fit_constraints([["hostname"|Constraint]|Rest], NodeHosts, NodeAttributes, 
+can_fit_constraints([["hostname"|Constraint]|Rest], NodeHosts, NodeAttributes,
                     OfferHelper) ->
     OfferHostname = get_hostname(OfferHelper),
     case fit_constraint(Constraint, OfferHostname, NodeHosts) of
@@ -148,7 +148,7 @@ can_fit_constraints([[Name|Constraint]|Rest], NodeHosts, NodeAttributes, OfferHe
     Attributes = get_attributes(OfferHelper),
     A = proplists:get_value(Name, Attributes),
     As = lists:foldl(
-           fun(X, Accum) -> 
+           fun(X, Accum) ->
                    [proplists:get_value(Name, X)|Accum]
            end, [], NodeAttributes),
     case fit_constraint(Constraint, A, As) of
@@ -256,7 +256,7 @@ get_unreserved_resources_ports(OfferHelper) ->
 -spec get_unreserved_applied_resources_ports(offer_helper()) ->
     [non_neg_integer()].
 get_unreserved_applied_resources_ports(OfferHelper) ->
-    UnreservedPorts = get_ranges_resource_values("ports", false, 
+    UnreservedPorts = get_ranges_resource_values("ports", false,
                           get_unreserved_applied_resources(OfferHelper)),
     UnreservedResources = resources(0.0, 0.0, 0.0, UnreservedPorts),
     erl_mesos_utils:resources_ports(UnreservedResources).
@@ -344,14 +344,14 @@ make_volume(Disk, Role, Principal, PersistenceId, ContainerPath,
 apply_reserved_resources(Cpus, Mem, Disk, NumPorts, Role, Principal,
                          PersistenceId, ContainerPath,
                          #offer_helper{reserved_resources = ReservedResources,
-                                       applied_reserved_resources = 
+                                       applied_reserved_resources =
                                            AppliedReservedResources} =
                          OfferHelper) ->
     {ReservedResources1, AppliedReservedResources1} =
         apply(Cpus, Mem, Disk, NumPorts, Role, Principal, PersistenceId,
               ContainerPath, ReservedResources),
     OfferHelper#offer_helper{reserved_resources = ReservedResources1,
-                             applied_reserved_resources = 
+                             applied_reserved_resources =
                                  AppliedReservedResources ++ AppliedReservedResources1}.
 
 -spec apply_unreserved_resources(undefined | float(), undefined | float(),
@@ -360,15 +360,15 @@ apply_reserved_resources(Cpus, Mem, Disk, NumPorts, Role, Principal,
     offer_helper().
 apply_unreserved_resources(Cpus, Mem, Disk, NumPorts,
                            #offer_helper{unreserved_resources =
-                                             UnreservedResources, 
-                                         applied_unreserved_resources = 
+                                             UnreservedResources,
+                                         applied_unreserved_resources =
                                              AppliedUnreservedResources} =
                            OfferHelper) ->
     {UnreservedResources1, AppliedUnreservedResources1} =
         apply(Cpus, Mem, Disk, NumPorts, undefined, undefined, undefined,
               undefined, UnreservedResources),
     OfferHelper#offer_helper{unreserved_resources = UnreservedResources1,
-                             applied_unreserved_resources = 
+                             applied_unreserved_resources =
                                  AppliedUnreservedResources ++ AppliedUnreservedResources1}.
 
 -spec get_reserved_applied_resources(offer_helper()) ->
@@ -791,38 +791,38 @@ unreserve_volumes([], VolumesToDestroy) ->
 -spec attributes_to_list([erl_mesos:'Attribute'()]) -> attributes().
 attributes_to_list(RawAttributes) ->
     attributes_to_list(RawAttributes, []).
-    
+
 -spec attributes_to_list([erl_mesos:'Attribute'()],
                          attributes()) -> attributes().
 attributes_to_list([], Accum) ->
     Accum;
 attributes_to_list([#'Attribute'{
-                     name=Name, 
-                     type='SCALAR', 
-                     scalar=#'Value.Scalar'{value=Value}}|Rest], 
+                     name=Name,
+                     type='SCALAR',
+                     scalar=#'Value.Scalar'{value=Value}}|Rest],
                    Accum) when is_float(Value) ->
     attributes_to_list(Rest, [{Name, float_to_list(Value)}|Accum]);
 attributes_to_list([#'Attribute'{
-                     type='RANGES', 
+                     type='RANGES',
                      ranges=#'Value.Scalar'{}}|Rest], Accum) ->
     %% TODO: Deal with range attributes
     attributes_to_list(Rest, Accum);
 attributes_to_list([#'Attribute'{
-                     type='SET', 
-                     scalar=#'Value.Set'{item=[]}}|Rest], 
+                     type='SET',
+                     scalar=#'Value.Set'{item=[]}}|Rest],
                    Accum) ->
     attributes_to_list(Rest, Accum);
 attributes_to_list([#'Attribute'{
-                     name=Name, 
-                     type='SET', 
-                     scalar=#'Value.Set'{item=[V1|_]=Value}}|Rest], 
+                     name=Name,
+                     type='SET',
+                     scalar=#'Value.Set'{item=[V1|_]=Value}}|Rest],
                    Accum) when is_list(V1) ->
     NewValues = lists:map(fun(X) -> {Name, X} end, Value),
     attributes_to_list(Rest, Accum ++ NewValues);
 attributes_to_list([#'Attribute'{
-                     name=Name, 
-                     type='TEXT', 
-                     scalar=#'Value.Text'{value=Value}}|Rest], 
+                     name=Name,
+                     type='TEXT',
+                     scalar=#'Value.Text'{value=Value}}|Rest],
                    Accum) when is_list(Value) ->
     attributes_to_list(Rest, [{Name, Value}|Accum]);
 attributes_to_list([_|Rest], Accum) ->
@@ -837,7 +837,7 @@ fit_constraint(Constraint, V, Vs) ->
     end.
 
 -spec can_fit_constraint(constraint(), string(), [string()]) -> boolean().
-can_fit_constraint(["UNIQUE"], V, Vs) -> 
+can_fit_constraint(["UNIQUE"], V, Vs) ->
     %% Unique Value
     not lists:member(V, Vs);
 can_fit_constraint(["GROUP_BY"], V, Vs) ->
@@ -863,10 +863,10 @@ can_fit_constraint(["GROUP_BY", Param], V, Vs) ->
             %% nodes evenly, because we already know how many nodes there are
             true
     end;
-can_fit_constraint(["CLUSTER", V], V, _) -> 
+can_fit_constraint(["CLUSTER", V], V, _) ->
     %% Cluster on value, values match
     true;
-can_fit_constraint(["CLUSTER", _], _, _) -> 
+can_fit_constraint(["CLUSTER", _], _, _) ->
     %% Cluster on value, hosts do not match
     false;
 can_fit_constraint(["LIKE", Param], V, _) ->
@@ -875,9 +875,9 @@ can_fit_constraint(["LIKE", Param], V, _) ->
         {match, _} -> true;
         nomatch -> false
     end;
-can_fit_constraint(["UNLIKE", Param], V, Vs) -> 
+can_fit_constraint(["UNLIKE", Param], V, Vs) ->
     %% Value is not like regex
     not can_fit_constraint(["LIKE", Param], V, Vs);
-can_fit_constraint(_, _, _) -> 
+can_fit_constraint(_, _, _) ->
     %% Undefined constraint, just schedule it
     true.

--- a/src/rms_offer_helper.erl
+++ b/src/rms_offer_helper.erl
@@ -201,7 +201,7 @@ get_reserved_resources(#offer_helper{reserved_resources = ReservedResources}) ->
 %% Returns true iff any reserved resource > 0
 -spec has_reserved_resources(offer_helper()) -> boolean().
 has_reserved_resources(OfferHelper) ->
-    Rsrcs = [ cpus, mem, disk, ports ],
+    Rsrcs = [ cpus, mem, disk, num_ports ],
     lists:sum([ get_reserved_resources(R, OfferHelper) || R <- Rsrcs ]) > 0.
 
 -spec get_reserved_resources(cpus | mem | disk | ports, offer_helper()) -> float() | [non_neg_integer()].
@@ -211,6 +211,8 @@ get_reserved_resources(mem, OfferHelper) ->
     get_reserved_resources_mem(OfferHelper);
 get_reserved_resources(disk, OfferHelper) ->
     get_reserved_resources_disk(OfferHelper);
+get_reserved_resources(num_ports, OfferHelper) ->
+    length(get_reserved_resources_ports(OfferHelper));
 get_reserved_resources(ports, OfferHelper) ->
     get_reserved_resources_ports(OfferHelper).
 
@@ -237,7 +239,7 @@ get_unreserved_resources(#offer_helper{unreserved_resources =
 
 -spec has_unreserved_resources(offer_helper()) -> boolean().
 has_unreserved_resources(OfferHelper) ->
-    Rsrcs = [ cpus, mem, disk, ports ],
+    Rsrcs = [ cpus, mem, disk, num_ports ],
     lists:sum([ get_unreserved_resources(R, OfferHelper) || R <- Rsrcs ]) > 0.
 
 -spec get_unreserved_resources(cpus | mem | disk | ports, offer_helper()) -> float() | [non_neg_integer()].
@@ -247,6 +249,8 @@ get_unreserved_resources(mem, OfferHelper) ->
     get_unreserved_resources_mem(OfferHelper);
 get_unreserved_resources(disk, OfferHelper) ->
     get_unreserved_resources_disk(OfferHelper);
+get_unreserved_resources(num_ports, OfferHelper) ->
+    length(get_unreserved_resources_ports(OfferHelper));
 get_unreserved_resources(ports, OfferHelper) ->
     get_unreserved_resources_ports(OfferHelper).
 

--- a/src/rms_offer_helper.erl
+++ b/src/rms_offer_helper.erl
@@ -13,12 +13,14 @@
          get_hostname/1,
          get_constraints/1,
          get_persistence_ids/1,
+         has_reserved_resources/1,
          get_reserved_resources/1,
          get_reserved_resources/2,
          get_reserved_resources_cpus/1,
          get_reserved_resources_mem/1,
          get_reserved_resources_disk/1,
          get_reserved_resources_ports/1,
+         has_unreserved_resources/1,
          get_unreserved_resources/1,
          get_unreserved_resources/2,
          get_unreserved_resources_cpus/1,
@@ -196,6 +198,12 @@ get_persistence_ids(#offer_helper{persistence_ids = PersistenceIds}) ->
 get_reserved_resources(#offer_helper{reserved_resources = ReservedResources}) ->
     ReservedResources.
 
+%% Returns true iff any reserved resource > 0
+-spec has_reserved_resources(offer_helper()) -> boolean().
+has_reserved_resources(OfferHelper) ->
+    Rsrcs = [ cpus, mem, disk, ports ],
+    lists:sum([ get_reserved_resources(R, OfferHelper) || R <- Rsrcs ]) > 0.
+
 -spec get_reserved_resources(cpus | mem | disk | ports, offer_helper()) -> float() | [non_neg_integer()].
 get_reserved_resources(cpus, OfferHelper) ->
     get_reserved_resources_cpus(OfferHelper);
@@ -226,6 +234,11 @@ get_reserved_resources_ports(OfferHelper) ->
 get_unreserved_resources(#offer_helper{unreserved_resources =
                                        UnreservedResources}) ->
     UnreservedResources.
+
+-spec has_unreserved_resources(offer_helper()) -> boolean().
+has_unreserved_resources(OfferHelper) ->
+    Rsrcs = [ cpus, mem, disk, ports ],
+    lists:sum([ get_unreserved_resources(R, OfferHelper) || R <- Rsrcs ]) > 0.
 
 -spec get_unreserved_resources(cpus | mem | disk | ports, offer_helper()) -> float() | [non_neg_integer()].
 get_unreserved_resources(cpus, OfferHelper) ->

--- a/src/rms_scheduler.erl
+++ b/src/rms_scheduler.erl
@@ -127,11 +127,11 @@ resource_offers(SchedulerInfo, #'Event.Offers'{offers = Offers}, State) ->
         {ok, State1} ->
             ExecsToShutdown = rms_cluster_manager:executors_to_shutdown(),
             case shutdown_executors(SchedulerInfo, ExecsToShutdown, State1) of
-                {ok, State2} -> 
+                {ok, State2} ->
                     %% Attempt to drain queue
                     exec_calls(State2);
                 Response2 -> Response2
-            end;            
+            end;
         Response1 ->
             Response1
     end.
@@ -151,9 +151,9 @@ offer_rescinded(_SchedulerInfo, #'Event.Rescind'{} = EventRescind, State) ->
 status_update(SchedulerInfo, #'Event.Update'{
                                  status=#'TaskStatus'{
                                            reason=Reason,
-                                           task_id=TaskId, 
-                                           agent_id=AgentId, 
-                                           state=NodeState, 
+                                           task_id=TaskId,
+                                           agent_id=AgentId,
+                                           state=NodeState,
                                            uuid=Uuid}} = EventUpdate, State)->
     lager:info("Scheduler received status update event. "
                "Update: ~p~n", [EventUpdate]),
@@ -169,8 +169,8 @@ status_update(SchedulerInfo, #'Event.Update'{
                     ok
             end
     end,
-    case Uuid of 
-        undefined -> 
+    case Uuid of
+        undefined ->
             {ok, State};
         _ ->
             call(acknowledge, [SchedulerInfo, AgentId, TaskId, Uuid], State)
@@ -353,7 +353,7 @@ exec_calls(#state{calls_queue = CallsQueue} = State) ->
             {ok, State1}
     end.
 
--spec apply_offers(erl_mesos_scheduler:scheduler_info(), [erl_mesos:'Offer'()], state()) -> 
+-spec apply_offers(erl_mesos_scheduler:scheduler_info(), [erl_mesos:'Offer'()], state()) ->
                           {ok, state()} | {stop, state()}.
 apply_offers(_, [], State) ->
     {ok, State};
@@ -368,7 +368,7 @@ apply_offers(SchedulerInfo, [Offer|Offers], #state{scheduler = #scheduler{option
             lager:info("Scheduler accept operations: ~p.", [Operations])
     end,
     case call(accept, [SchedulerInfo, [OfferId], Operations, Filters], State) of
-        {ok, State1} -> 
+        {ok, State1} ->
             apply_offers(SchedulerInfo, Offers, State1);
         _ -> {stop, State}
     end.
@@ -423,20 +423,20 @@ shutdown_executors(SchedulerInfo, [{ExecutorValue, AgentIdValue}|Rest], State) -
     AgentId = erl_mesos_utils:agent_id(AgentIdValue),
     ExecutorId = erl_mesos_utils:executor_id(ExecutorValue),
     lager:info("Finishing ~p.", [ExecutorValue]),
-    case call(message, 
-              [SchedulerInfo, AgentId, 
+    case call(message,
+              [SchedulerInfo, AgentId,
                ExecutorId, <<"finish">>], State) of
         {ok, S1} ->
             lager:info("Told ~p to finish.", [ExecutorValue]),
             shutdown_executors(SchedulerInfo, Rest, S1);
-        R -> 
+        R ->
             lager:info("Error telling node to finish: ~p.", [R]),
             R
     end.
 
 -spec handle_call_exec_error(atom(), [term()], term()) -> ok.
-handle_call_exec_error(message, [_, 
-                                 #'AgentID'{}, 
+handle_call_exec_error(message, [_,
+                                 #'AgentID'{},
                                  #'ExecutorID'{value = ExecutorId},
                                  <<"finish">>], closed=Reason) ->
     %% The node we're attempting to finish is no longer running

--- a/src/rms_scheduler.erl
+++ b/src/rms_scheduler.erl
@@ -378,7 +378,7 @@ apply_offers(SchedulerInfo, [Offer|Offers], #state{scheduler = #scheduler{option
 apply_offer(Offer, Constraints) ->
     OfferHelper = rms_offer_helper:new(Offer),
     OfferHelper1 = rms_offer_helper:set_constraints(Constraints, OfferHelper),
-    lager:info("Scheduler recevied offer. "
+    lager:info("Scheduler received offer. "
                "Offer id: ~s. "
                "Resources: ~p. "
                "Constraints: ~p. ",

--- a/src/rms_wm_resource.erl
+++ b/src/rms_wm_resource.erl
@@ -333,10 +333,10 @@ restart_node(RD) ->
 
 get_node_aae(ReqData) ->
     riak_explorer_command(ReqData, aae_status).
-     
+
 get_node_status(ReqData) ->
     riak_explorer_command(ReqData, status).
-     
+
 get_node_ringready(ReqData) ->
     riak_explorer_command(ReqData, ringready).
 
@@ -358,7 +358,7 @@ set_node_bucket_type(ReqData) ->
 
 healthcheck(ReqData) ->
     {[{success, true}], ReqData}.
-    
+
 %% wm callback functions.
 
 init(_) ->

--- a/test/rms_offer_helper_SUITE.erl
+++ b/test/rms_offer_helper_SUITE.erl
@@ -440,11 +440,11 @@ test_hostname_constraint(Constraints, Hostname, NodeHosts) ->
                       ports_resources() ++
                       volume_resources(),
     rms_offer_helper:can_fit_constraints(
-            rms_offer_helper:set_constraints(Constraints, 
+            rms_offer_helper:set_constraints(Constraints,
             rms_offer_helper:set_node_hostnames(NodeHosts,
             rms_offer_helper:set_node_attributes([[]],
-            rms_offer_helper:new(offer("offer_1", OfferResources1, 
-              Hostname, 
+            rms_offer_helper:new(offer("offer_1", OfferResources1,
+              Hostname,
               []
             )))))).
 
@@ -454,10 +454,10 @@ test_attribute_constraint(Constraints, [{Attr,AttrVal}], NodeAttrs) ->
                       ports_resources() ++
                       volume_resources(),
     rms_offer_helper:can_fit_constraints(
-            rms_offer_helper:set_constraints(Constraints, 
+            rms_offer_helper:set_constraints(Constraints,
             rms_offer_helper:set_node_hostnames([],
             rms_offer_helper:set_node_attributes(NodeAttrs,
-            rms_offer_helper:new(offer("offer_1", OfferResources1, 
-              "ubuntu.local", 
+            rms_offer_helper:new(offer("offer_1", OfferResources1,
+              "ubuntu.local",
               [#'Attribute'{name=Attr,type='TEXT',scalar=#'Value.Text'{value=AttrVal}}]
             )))))).

--- a/test/rms_offer_helper_SUITE.erl
+++ b/test/rms_offer_helper_SUITE.erl
@@ -270,101 +270,111 @@ apply_resources(_Config) ->
     AfterApplyPortsLength = length(AfterApplyPorts).
 
 can_fit_hostname_constraints(_Config) ->
-    false = test_hostname_constraint(
+    {error, ["hostname", "UNIQUE"]} =
+        test_hostname_constraint(
               [["hostname", "UNIQUE"]],
               "ubuntu1.local",
               ["ubuntu1.local"]),
-    true = test_hostname_constraint(
+    ok = test_hostname_constraint(
               [["hostname", "UNIQUE"]],
               "ubuntu2.local",
               ["ubuntu1.local"]),
-    true = test_hostname_constraint(
+    ok = test_hostname_constraint(
               [["hostname", "GROUP_BY"]],
               "ubuntu1.local",
               ["ubuntu1.local"]),
-    true = test_hostname_constraint(
+    ok = test_hostname_constraint(
               [["hostname", "GROUP_BY"]],
               "ubuntu2.local",
               ["ubuntu1.local"]),
-    false = test_hostname_constraint(
+    {error, ["hostname", "GROUP_BY", "2"]} =
+        test_hostname_constraint(
               [["hostname", "GROUP_BY", "2"]],
               "ubuntu1.local",
               ["ubuntu1.local"]),
-    true = test_hostname_constraint(
+    ok = test_hostname_constraint(
               [["hostname", "GROUP_BY", "1"]],
               "ubuntu2.local",
               ["ubuntu1.local"]),
-    true = test_hostname_constraint(
+    ok = test_hostname_constraint(
               [["hostname", "CLUSTER", "ubuntu1.local"]],
               "ubuntu1.local",
               ["ubuntu1.local"]),
-    false = test_hostname_constraint(
+    {error, ["hostname", "CLUSTER", "ubuntu1.local"]} =
+        test_hostname_constraint(
               [["hostname", "CLUSTER", "ubuntu1.local"]],
               "ubuntu2.local",
               ["ubuntu1.local"]),
-    false = test_hostname_constraint(
+    {error, ["hostname", "LIKE", "ubuntu[1-2].local"]} =
+        test_hostname_constraint(
               [["hostname", "LIKE", "ubuntu[1-2].local"]],
               "ubuntu3.local",
               ["ubuntu1.local"]),
-    true = test_hostname_constraint(
+    ok = test_hostname_constraint(
               [["hostname", "LIKE", "ubuntu[1-2].local"]],
               "ubuntu1.local",
               ["ubuntu1.local"]),
-    true = test_hostname_constraint(
+    ok = test_hostname_constraint(
               [["hostname", "UNLIKE", "ubuntu[1-2].local"]],
               "ubuntu3.local",
               ["ubuntu1.local"]),
-    false = test_hostname_constraint(
+    {error, ["hostname", "UNLIKE", "ubuntu[1-2].local"]} =
+        test_hostname_constraint(
               [["hostname", "UNLIKE", "ubuntu[1-2].local"]],
               "ubuntu1.local",
               ["ubuntu1.local"]).
 
 can_fit_attribute_constraints(_Config) ->
-    false = test_attribute_constraint(
+    {error, ["rack_id", "UNIQUE"]} =
+        test_attribute_constraint(
               [["rack_id", "UNIQUE"]],
               [{"rack_id", "1"}],
               [[{"rack_id", "1"}]]),
-    true = test_attribute_constraint(
+    ok = test_attribute_constraint(
               [["rack_id", "UNIQUE"]],
               [{"rack_id", "2"}],
               [[{"rack_id", "1"}]]),
-    true = test_attribute_constraint(
+    ok = test_attribute_constraint(
               [["rack_id", "GROUP_BY"]],
               [{"rack_id", "1"}],
               [[{"rack_id", "1"}]]),
-    true = test_attribute_constraint(
+    ok = test_attribute_constraint(
               [["rack_id", "GROUP_BY"]],
               [{"rack_id", "2"}],
               [[{"rack_id", "1"}]]),
-    false = test_attribute_constraint(
+    {error, ["rack_id", "GROUP_BY", "2"]} =
+        test_attribute_constraint(
               [["rack_id", "GROUP_BY", "2"]],
               [{"rack_id", "1"}],
               [[{"rack_id", "1"}]]),
-    true = test_attribute_constraint(
+    ok = test_attribute_constraint(
               [["rack_id", "GROUP_BY", "1"]],
               [{"rack_id", "1"}],
               [[{"rack_id", "1"}]]),
-    true = test_attribute_constraint(
+    ok = test_attribute_constraint(
               [["rack_id", "CLUSTER", "1"]],
               [{"rack_id", "1"}],
               [[{"rack_id", "1"}]]),
-    false = test_attribute_constraint(
+    {error, ["rack_id", "CLUSTER", "2"]} =
+        test_attribute_constraint(
               [["rack_id", "CLUSTER", "2"]],
               [{"rack_id", "1"}],
               [[{"rack_id", "1"}]]),
-    false = test_attribute_constraint(
+    {error, ["rack_id", "LIKE", "[1-2]"]} =
+        test_attribute_constraint(
               [["rack_id", "LIKE", "[1-2]"]],
               [{"rack_id", "3"}],
               [[{"rack_id", "1"}]]),
-    true = test_attribute_constraint(
+    ok = test_attribute_constraint(
               [["rack_id", "LIKE", "[1-2]"]],
               [{"rack_id", "1"}],
               [[{"rack_id", "1"}]]),
-    true = test_attribute_constraint(
+    ok = test_attribute_constraint(
               [["rack_id", "UNLIKE", "[1-2]"]],
               [{"rack_id", "3"}],
               [[{"rack_id", "1"}]]),
-    false = test_attribute_constraint(
+    {error, ["rack_id", "UNLIKE", "[1-2]"]} =
+        test_attribute_constraint(
               [["rack_id", "UNLIKE", "[1-2]"]],
               [{"rack_id", "1"}],
               [[{"rack_id", "1"}]]).


### PR DESCRIPTION
This addresses a couple of issues ( #64 and #66 ), as well as generally cleans up the logic for applying resources to nodes.

The logic for applying resources previously was (thanks to @drewkerrigan for putting this quite so succinctly):

```
receive offer, iterate through nodes
   does node have reservation?
      yes -> try to use offer
      no -> try to use offer
```

Now, we do the somewhat more sensible:

```
Receive offer, does offer have reserved resources?
  yes -> try to use offer with nodes with reservations
  no -> try to use offer with nodes without reservations
```

Also a little whitespace 👾  for good measure.