### PR TITLE
Raw access log from webmachine

### DIFF
--- a/rel/sys.config
+++ b/rel/sys.config
@@ -46,6 +46,10 @@
    {crash_log,"./log/crash.log"},
    {crash_log_count,5}
   ]},
+ {webmachine,
+  [{log_handlers,
+    [{webmachine_access_log_handler, ["log"]}]}
+  ]},
  {os_mon,
   [
    {start_disksup,false},


### PR DESCRIPTION
This provides an extra logfile in `riak_mesos_scheduler/log/access.log.YYYY-MM-DD-HH` with all http requests serviced by webmachine.

e.g.
```
127.0.0.1 - - [27/Jul/2016:14:52:21 +0000] "PUT /api/v1/clusters/default HTTP/1.1" 200 16 "" "python-requests/2.10.0"
127.0.0.1 - - [27/Jul/2016:14:52:26 +0000] "GET /healthcheck HTTP/1.1" 200 16 "" "python-requests/2.10.0"
127.0.0.1 - - [27/Jul/2016:14:52:26 +0000] "POST /api/v1/clusters/default/nodes HTTP/1.1" 200 16 "" "python-requests/2.10.0"
127.0.0.1 - - [27/Jul/2016:14:52:26 +0000] "POST /api/v1/clusters/default/nodes HTTP/1.1" 200 16 "" "python-requests/2.10.0"
127.0.0.1 - - [27/Jul/2016:14:52:26 +0000] "POST /api/v1/clusters/default/nodes HTTP/1.1" 200 16 "" "python-requests/2.10.0"
127.0.0.1 - - [27/Jul/2016:14:52:33 +0000] "GET /healthcheck HTTP/1.1" 200 16 "" "spray-can/1.3.2"
127.0.0.1 - - [27/Jul/2016:14:52:33 +0000] "GET /static/riak_mesos_executor-1.2.0-7-g02f978b-mesos-0.28.1-ubuntu-14.04.tar.gz HTTP/1.1" 200 24741237 "" ""
127.0.0.1 - - [27/Jul/2016:14:52:34 +0000] "GET /static/riak_explorer-1.1.1.patch-ubuntu-14.04.tar.gz HTTP/1.1" 200 5807957 "" ""
127.0.0.1 - - [27/Jul/2016:14:52:34 +0000] "GET /static/riak_erlpmd_patches-1.2.0-1-ge364c0b-mesos-0.28.1-ubuntu-14.04.tar.gz HTTP/1.1" 200 5209 "" ""
127.0.0.1 - - [27/Jul/2016:14:52:34 +0000] "GET /static/riak_ee-2.1.4.tgz HTTP/1.1" 200 74877558 "" ""
127.0.0.1 - - [27/Jul/2016:14:52:36 +0000] "GET //api/v1/clusters/default/config HTTP/1.1" 200 13521 "" "hackney/1.6.0"
127.0.0.1 - - [27/Jul/2016:14:52:36 +0000] "GET //api/v1/clusters/default/advancedConfig HTTP/1.1" 200 231 "" "hackney/1.6.0"
127.0.0.1 - - [27/Jul/2016:14:52:45 +0000] "GET /static/riak_mesos_executor-1.2.0-7-g02f978b-mesos-0.28.1-ubuntu-14.04.tar.gz HTTP/1.1" 200 24741237 "" ""
127.0.0.1 - - [27/Jul/2016:14:52:46 +0000] "GET /static/riak_explorer-1.1.1.patch-ubuntu-14.04.tar.gz HTTP/1.1" 200 5807957 "" ""
127.0.0.1 - - [27/Jul/2016:14:52:46 +0000] "GET /static/riak_erlpmd_patches-1.2.0-1-ge364c0b-mesos-0.28.1-ubuntu-14.04.tar.gz HTTP/1.1" 200 5209 "" ""
127.0.0.1 - - [27/Jul/2016:14:52:46 +0000] "GET /static/riak_ee-2.1.4.tgz HTTP/1.1" 200 74877558 "" ""
127.0.0.1 - - [27/Jul/2016:14:52:48 +0000] "GET //api/v1/clusters/default/config HTTP/1.1" 200 13521 "" "hackney/1.6.0"
127.0.0.1 - - [27/Jul/2016:14:52:48 +0000] "GET //api/v1/clusters/default/advancedConfig HTTP/1.1" 200 231 "" "hackney/1.6.0"
127.0.0.1 - - [27/Jul/2016:14:52:57 +0000] "GET /static/riak_mesos_executor-1.2.0-7-g02f978b-mesos-0.28.1-ubuntu-14.04.tar.gz HTTP/1.1" 200 24741237 "" ""
127.0.0.1 - - [27/Jul/2016:14:52:58 +0000] "GET /static/riak_explorer-1.1.1.patch-ubuntu-14.04.tar.gz HTTP/1.1" 200 5807957 "" ""
127.0.0.1 - - [27/Jul/2016:14:52:58 +0000] "GET /static/riak_erlpmd_patches-1.2.0-1-ge364c0b-mesos-0.28.1-ubuntu-14.04.tar.gz HTTP/1.1" 200 5209 "" ""
127.0.0.1 - - [27/Jul/2016:14:52:58 +0000] "GET /static/riak_ee-2.1.4.tgz HTTP/1.1" 200 74877558 "" ""
127.0.0.1 - - [27/Jul/2016:14:53:00 +0000] "GET //api/v1/clusters/default/config HTTP/1.1" 200 13521 "" "hackney/1.6.0"
127.0.0.1 - - [27/Jul/2016:14:53:00 +0000] "GET //api/v1/clusters/default/advancedConfig HTTP/1.1" 200 231 "" "hackney/1.6.0"
```

If we want to a) change the name/logrotate frequency ; or b) change the contents, we'll need to create our own version of `webmachine_access_log_handler` (a `gen_event` handler) to do that.

Perhaps that can be a longer-term goal and we can add this for now?
/cc @seanjensengrey 