### PR TITLE
Add optional .riak.node.network_interface_name to config.json

### DIFF
--- a/priv/riak.conf.default
+++ b/priv/riak.conf.default
@@ -282,7 +282,7 @@ platform_log_dir = ./log
 ##
 ## Acceptable values:
 ##   - an IP/port pair, e.g. 127.0.0.1:10011
-listener.http.internal = 0.0.0.0:{{httpport}}
+listener.http.internal = {{bindaddress}}:{{httpport}}
 
 ## listener.protobuf.<name> is an IP address and TCP port that the Riak
 ## Protocol Buffers interface will bind.
@@ -291,7 +291,7 @@ listener.http.internal = 0.0.0.0:{{httpport}}
 ##
 ## Acceptable values:
 ##   - an IP/port pair, e.g. 127.0.0.1:10011
-listener.protobuf.internal = 0.0.0.0:{{pbport}}
+listener.protobuf.internal = {{bindaddress}}:{{pbport}}
 
 ## The maximum length to which the queue of pending connections
 ## may grow. If set, it must be an integer > 0. If you anticipate a

--- a/priv/riak.conf.default
+++ b/priv/riak.conf.default
@@ -282,7 +282,7 @@ platform_log_dir = ./log
 ##
 ## Acceptable values:
 ##   - an IP/port pair, e.g. 127.0.0.1:10011
-listener.http.internal = {{bindaddress}}:{{httpport}}
+listener.http.internal = 0.0.0.0:{{httpport}}
 
 ## listener.protobuf.<name> is an IP address and TCP port that the Riak
 ## Protocol Buffers interface will bind.
@@ -291,7 +291,7 @@ listener.http.internal = {{bindaddress}}:{{httpport}}
 ##
 ## Acceptable values:
 ##   - an IP/port pair, e.g. 127.0.0.1:10011
-listener.protobuf.internal = {{bindaddress}}:{{pbport}}
+listener.protobuf.internal = 0.0.0.0:{{pbport}}
 
 ## The maximum length to which the queue of pending connections
 ## may grow. If set, it must be an integer > 0. If you anticipate a

--- a/src/rms_erl_mesos_utils.erl
+++ b/src/rms_erl_mesos_utils.erl
@@ -1,0 +1,23 @@
+-module(rms_erl_mesos_utils).
+
+-export([
+         environment_variable/2,
+         environment/1,
+         set_command_info_environment/2
+        ]).
+
+-include_lib("erl_mesos/include/scheduler_protobuf.hrl").
+
+set_command_info_environment(#'CommandInfo'{}=CI0, #'Environment'{}=E0) ->
+    CI0#'CommandInfo'{environment = E0}.
+
+environment_variable(Name, Value) ->
+    #'Environment.Variable'{
+       name = Name,
+       value = Value
+    }.
+
+environment(Variables) ->
+    #'Environment'{
+       variables = Variables
+      }.

--- a/src/rms_node_manager.erl
+++ b/src/rms_node_manager.erl
@@ -404,7 +404,18 @@ apply_reserved_offer(NodeKey, OfferHelper) ->
 
                     CommandInfoValue = "./riak_mesos_executor/bin/ermf-executor",
                     UrlList = [ExecutorUrl, RiakExplorerUrl, RiakPatchesUrl, RiakUrl],
-                    CommandInfo = erl_mesos_utils:command_info(CommandInfoValue, UrlList),
+                    CommandInfo0 = erl_mesos_utils:command_info(CommandInfoValue, UrlList),
+                    %% TODO Raise PR against erl_mesos to allow managing Environment records
+                    RiakIface = rms_metadata:get_option(node_iface),
+                    CommandInfo =
+                        case RiakIface of
+                            "" -> CommandInfo0;
+                            Iface ->
+                                NodeIfaceEnv = rms_erl_mesos_utils:environment_variable(
+                                                 "RIAK_MESOS_NODE_IFACE", Iface),
+                                CmdEnv = rms_erl_mesos_utils:environment([NodeIfaceEnv]),
+                                rms_erl_mesos_utils:set_command_info_environment(CommandInfo0, CmdEnv)
+                        end,
 
                     TaskId = erl_mesos_utils:task_id(NodeKey),
 

--- a/src/rms_node_manager.erl
+++ b/src/rms_node_manager.erl
@@ -406,7 +406,7 @@ apply_reserved_offer(NodeKey, OfferHelper) ->
                     UrlList = [ExecutorUrl, RiakExplorerUrl, RiakPatchesUrl, RiakUrl],
                     CommandInfo0 = erl_mesos_utils:command_info(CommandInfoValue, UrlList),
                     %% TODO Raise PR against erl_mesos to allow managing Environment records
-                    RiakIface = rms_metadata:get_option(node_iface),
+                    {ok, RiakIface} = rms_metadata:get_option(node_iface),
                     CommandInfo =
                         case RiakIface of
                             "" -> CommandInfo0;

--- a/src/rms_sup.erl
+++ b/src/rms_sup.erl
@@ -70,6 +70,7 @@ init([]) ->
     NodeCpus = rms_config:get_value(node_cpus, 0.5, number),
     NodeMem = rms_config:get_value(node_mem, 1024.0, number),
     NodeDisk = rms_config:get_value(node_disk, 4000.0, number),
+    NodeIface = rms_config:get_value(node_iface, "", string),
 
     ExecutorCpus = rms_config:get_value(executor_cpus, 0.1, number),
     ExecutorMem = rms_config:get_value(executor_mem, 512.0, number),
@@ -90,6 +91,7 @@ init([]) ->
                         {node_cpus, NodeCpus},
                         {node_mem, NodeMem},
                         {node_disk, NodeDisk},
+                        {node_iface, NodeIface},
                         {executor_cpus, ExecutorCpus},
                         {executor_mem, ExecutorMem},
                         {artifact_urls, ArtifactUrls}],


### PR DESCRIPTION
This PR adds some mechanisms necessary for the scheduler to pass configuration to its executors via their execution environment.

The first example is `RIAK_MESOS_NODE_IFACE`: a value optionally specified in config at `.riak.node.network_interface_name`. Details of its purpose can be found here: basho-labs/riak-mesos-executor#26

~~TODO Revert the `riak.conf.default` file - we don't need to use this variable by default, only if an operator wishes to do so.~~ EDIT: DONE