### PR TITLE
Configurable Persistent Volume path

### DIFF
--- a/priv/riak.conf.default
+++ b/priv/riak.conf.default
@@ -243,7 +243,11 @@ platform_bin_dir = ./bin
 ##
 ## Acceptable values:
 ##   - the path to a directory
-platform_data_dir = ./data
+## For Mesos, we set this to where the scheduler will put the
+## the persistent volume
+## To use something configurable from the executor, set to
+## {{data_dir}}
+platform_data_dir = ../../data
 
 ##
 ## Default: ./etc

--- a/src/rms_config.erl
+++ b/src/rms_config.erl
@@ -21,6 +21,7 @@
 -module(rms_config).
 
 -export([master_hosts/0,
+         static_root/0,
          constraints/0,
          zk/0,
          framework_name/0,
@@ -35,6 +36,7 @@
 -define(DEFAULT_MASTER, "master.mesos:5050").
 -define(DEFAULT_ZK, "master.mesos:2181").
 -define(DEFAULT_CONSTRAINTS, "[]").
+-define(STATIC_ROOT, "../artifacts/").
 
 %% Helper functions.
 
@@ -42,6 +44,9 @@
 master_hosts() ->
     {Hosts, _} = split_hosts(get_value(master, ?DEFAULT_MASTER, string)),
     Hosts.
+
+-spec static_root() -> string().
+static_root() -> ?STATIC_ROOT.
 
 -spec constraints() -> rms_offer_helper:constraints().
 constraints() ->

--- a/src/rms_config.erl
+++ b/src/rms_config.erl
@@ -116,6 +116,7 @@ artifacts() ->
 
 -spec artifact_urls() -> [string()].
 artifact_urls() ->
+    %% TODO "static" is magic
     Base = webui_url() ++ "static/",
     [ Base ++ Artifact || Artifact <- artifacts() ].
 

--- a/src/rms_config.erl
+++ b/src/rms_config.erl
@@ -122,7 +122,7 @@ artifact_urls() ->
 
 -spec persistent_path() -> string().
 persistent_path() ->
-    get_value(persistent_path, "root", string).
+    get_value(persistent_path, "data", string).
 
 %% External functions.
 

--- a/src/rms_config.erl
+++ b/src/rms_config.erl
@@ -26,7 +26,9 @@
          zk/0,
          framework_name/0,
          webui_url/0, 
+         artifacts/0,
          artifact_urls/0, 
+         persistent_path/0,
          framework_hostname/0]).
 
 -export([get_value/2, get_value/3]).
@@ -103,15 +105,23 @@ webui_url() ->
     Port = rms_config:get_value(port, 9090, integer),
     "http://" ++ Hostname ++ ":" ++ integer_to_list(Port) ++ "/".
 
+-spec artifacts() -> [string()].
+artifacts() ->
+    [
+     get_value(riak_pkg, "riak.tar.gz", string),
+     get_value(explorer_pkg, "riak_explorer.tar.gz", string),
+     get_value(patches_pkg, "riak_erlpmd_patches.tar.gz", string),
+     get_value(executor_pkg, "riak_mesos_executor.tar.gz", string)
+    ].
+
 -spec artifact_urls() -> [string()].
 artifact_urls() ->
     Base = webui_url() ++ "static/",
-    [
-     Base ++ get_value(riak_pkg, "riak.tar.gz", string),
-     Base ++ get_value(explorer_pkg, "riak_explorer.tar.gz", string),
-     Base ++ get_value(patches_pkg, "riak_erlpmd_patches.tar.gz", string),
-     Base ++ get_value(executor_pkg, "riak_mesos_executor.tar.gz", string)
-    ].
+    [ Base ++ Artifact || Artifact <- artifacts() ].
+
+-spec persistent_path() -> string().
+persistent_path() ->
+    get_value(persistent_path, "root", string).
 
 %% External functions.
 

--- a/src/rms_node_manager.erl
+++ b/src/rms_node_manager.erl
@@ -64,8 +64,6 @@
 
 -define(NODE_NUM_PORTS, 10).
 
--define(NODE_CONTAINER_PATH, "root").
-
 -define(CPUS_PER_EXECUTOR, 0.1).
 
 -define(MEM_PER_EXECUTOR, 32.0).
@@ -282,8 +280,8 @@ apply_unreserved_offer(NodeKey, OfferHelper) ->
             {ok, NodeCpus} = rms_metadata:get_option(node_cpus),
             {ok, NodeMem} = rms_metadata:get_option(node_mem),
             {ok, NodeDisk} = rms_metadata:get_option(node_disk),
+            {ok, ContainerPath} = rms_metadata:get_option(persistent_path),
             NodeNumPorts = ?NODE_NUM_PORTS,
-            ContainerPath = ?NODE_CONTAINER_PATH,
             Hostname = rms_offer_helper:get_hostname(OfferHelper),
             AgentIdValue = rms_offer_helper:get_agent_id_value(OfferHelper),
             PersistenceId = node_persistence_id(),
@@ -339,8 +337,8 @@ apply_reserved_offer(NodeKey, OfferHelper) ->
             {ok, NodeMem} = rms_metadata:get_option(node_mem),
             {ok, NodeDisk} = rms_metadata:get_option(node_disk),
             {ok, ArtifactUrls} = rms_metadata:get_option(artifact_urls),
+            {ok, ContainerPath} = rms_metadata:get_option(persistent_path),
             NodeNumPorts = ?NODE_NUM_PORTS,
-            ContainerPath = ?NODE_CONTAINER_PATH,
             UnfitForReserved =
                 rms_offer_helper:unfit_for_reserved(
                   [{cpus, NodeCpus}, {mem, NodeMem},

--- a/src/rms_sup.erl
+++ b/src/rms_sup.erl
@@ -37,9 +37,45 @@ start_link() ->
 -spec init([]) ->
     {ok, {{supervisor:strategy(), 1, 1}, [supervisor:child_spec()]}}.
 init([]) ->
+    PersistentVolPath = rms_config:persistent_path(),
+    ArtifactsDir = rms_config:static_root(),
+    Artifacts = rms_config:artifacts(),
+    %% For each artifact, make sure it does not contain PersistentVolPath:
+    %% if it does, DO NOT START, print something very, very clear
+    case persistent_vol_failsafe(PersistentVolPath, ArtifactsDir, Artifacts) of
+        {error, {path_clash, Artifact}} ->
+            lager:error("Unable to start scheduler: a path in ~p will overwrite"
+                        " the persistent volume path (~p) in executors. Refusing to start.",
+                        %% TODO Maybe add a link to some info in the logline? Is that naive?
+                        [Artifact, PersistentVolPath]),
+            {error, path_clash};
+        {error, _} = Error ->
+            lager:error("Unable to validate archives against persistent volume path, because: ~p",
+                        [Error]),
+            Error;
+        ok -> init_rest()
+    end.
+
+persistent_vol_failsafe(_, _, []) -> ok;
+persistent_vol_failsafe(PVPath, ArtsDir, [Art | Artifacts]) ->
+    Artifact = filename:join(ArtsDir, Art),
+    case erl_tar:table(Artifact, [compressed]) of
+        {error, _}=Error -> Error ;
+        {ok, Contents} ->
+            case lists:member(PVPath, Contents) orelse
+                    lists:member(PVPath++"/", Contents) of
+                true -> {error, {path_clash, Art}};
+                false ->
+                    persistent_vol_failsafe(PVPath, ArtsDir, Artifacts)
+            end
+    end.
+
+-spec init_rest() ->
+    {ok, {{supervisor:strategy(), 1, 1}, [supervisor:child_spec()]}}.
+init_rest() ->
     Ip = rms_config:get_value(ip, "0.0.0.0"),
     Port = rms_config:get_value(port, 9090, integer),
-    WebConfig = 
+    WebConfig =
         [{ip, Ip},
          {port, Port},
          {nodelay, true},
@@ -75,6 +111,7 @@ init([]) ->
     ExecutorCpus = rms_config:get_value(executor_cpus, 0.1, number),
     ExecutorMem = rms_config:get_value(executor_mem, 512.0, number),
 
+    PersistentVolPath = rms_config:persistent_path(),
     ArtifactUrls = rms_config:artifact_urls(),
 
     Ref = riak_mesos_scheduler,
@@ -92,6 +129,7 @@ init([]) ->
                         {node_mem, NodeMem},
                         {node_disk, NodeDisk},
                         {node_iface, NodeIface},
+                        {persistent_path, PersistentVolPath},
                         {executor_cpus, ExecutorCpus},
                         {executor_mem, ExecutorMem},
                         {artifact_urls, ArtifactUrls}],

--- a/src/rms_wm_resource.erl
+++ b/src/rms_wm_resource.erl
@@ -91,6 +91,7 @@
 routes() ->
     [%% Static.
      #route{base = [],
+            %% TODO "static" is magic
             path = ["static", static_resource],
             exists = {?MODULE, static_file_exists},
             provides = {?MODULE, static_types},

--- a/src/rms_wm_resource.erl
+++ b/src/rms_wm_resource.erl
@@ -50,7 +50,6 @@
          create_path/2,
          last_modified/2]).
 
--define(STATIC_ROOT, "../artifacts/").
 -define(API_BASE, "api").
 -define(API_VERSION, "v1").
 -define(API_ROUTE, [?API_BASE, ?API_VERSION]).
@@ -474,7 +473,7 @@ build_response({error, Error}) ->
 
 static_filename(ReqData) ->
     Resource = wrq:path_info(static_resource, ReqData),
-    filename:join([?STATIC_ROOT, Resource]).
+    filename:join([rms_config:static_root(), Resource]).
 
 hash_body(Body) -> mochihex:to_hex(binary_to_list(crypto:hash(sha,Body))).
 


### PR DESCRIPTION
Allow setting (via the env var `RIAK_MESOS_PERSISTENT_PATH`) the path under which the scheduler will create the persistent volume for riak to use as a data dir.

Also add a failsafe to the scheduler init procedure, to ensure that we never try to give mesos an archive that will overwrite the persistent volume symlink.

NB: If you use custom riak.conf files and upgrade to this version, you will need to update your riak.conf with `platform_data_dir = ../../data` to match the default location.