### PR TITLE
Fix cluster info endpoint

### DIFF
--- a/src/rms_wm_resource.erl
+++ b/src/rms_wm_resource.erl
@@ -226,7 +226,7 @@ get_cluster(ReqData) ->
     Status = proplists:get_value(status, Cluster),
     RiakConfig = proplists:get_value(riak_config, Cluster),
     AdvancedConfig = proplists:get_value(advanced_config, Cluster),
-    NodeKeys = proplists:get_value(node_keys, Cluster),
+    NodeKeys = rms_node_manager:get_node_keys(Key),
     BinNodeKeys = [list_to_binary(NodeKey) || NodeKey <- NodeKeys],
     ClusterData = [{Key, [{key, list_to_binary(Key)},
                           {status, Status},


### PR DESCRIPTION
The `node_keys` key was removed from cluster metadata, use `rms_node_manager:get_node_keys/1` instead.

```
$ riak-mesos cluster info | jq .default.node_keys
[
  "riak-default-4",
  "riak-default-1",
  "riak-default-3",
  "riak-default-5",
  "riak-default-2"
]
```