### PR TITLE
Support of multiple frameworks improved

### DIFF
--- a/src/rms_config.erl
+++ b/src/rms_config.erl
@@ -25,6 +25,7 @@
          constraints/0,
          zk/0,
          framework_name/0,
+         framework_role/0,
          webui_url/0, 
          artifacts/0,
          artifact_urls/0, 
@@ -85,6 +86,10 @@ zk() ->
 -spec framework_name() -> string().
 framework_name() ->
     get_value(name, ?DEFAULT_NAME, string).
+
+-spec framework_role() -> string().
+framework_role() ->
+    get_value(name, framework_name(), string).
 
 -spec framework_hostname() -> string().
 framework_hostname() ->

--- a/src/rms_config.erl
+++ b/src/rms_config.erl
@@ -35,7 +35,7 @@
 -export([get_value/2, get_value/3]).
 
 -define(DEFAULT_NAME, "riak").
--define(DEFAULT_HOSTNAME, "riak.mesos").
+-define(DEFAULT_HOSTNAME_SUFFIX, ".marathon.mesos").
 -define(DEFAULT_MASTER, "master.mesos:5050").
 -define(DEFAULT_ZK, "master.mesos:2181").
 -define(DEFAULT_CONSTRAINTS, "[]").
@@ -95,13 +95,9 @@ framework_role() ->
 framework_hostname() ->
     case get_value(hostname, undefined, string) of
         undefined ->
-            {ok, LH} = inet:gethostname(),
-            case inet:gethostbyname(LH) of
-                {ok, {_, FullHostname, _, _, _, _}} ->
-                    FullHostname;
-                _ -> ?DEFAULT_HOSTNAME
-            end;
-        HN -> HN
+            framework_name() ++ ?DEFAULT_HOSTNAME_SUFFIX;
+        Hostname ->
+            Hostname
     end.
 
 -spec webui_url() -> string().

--- a/src/rms_sup.erl
+++ b/src/rms_sup.erl
@@ -91,7 +91,7 @@ init_rest() ->
                    end || Node <- ZkNodes],
     FrameworkUser = rms_config:get_value(user, "root"),
     FrameworkName = rms_config:framework_name(),
-    FrameworkRole = rms_config:get_value(role, "riak", string),
+    FrameworkRole = rms_config:framework_role(),
     FrameworkHostname = rms_config:framework_hostname(),
     FrameworkPrincipal = rms_config:get_value(principal, "riak", string),
     FrameworkFailoverTimeout =


### PR DESCRIPTION
Changes:

- framework_role - optional (default framework_name)
- framework_hostname - optional (default ${framework_name}.marathon.mesos) 