### PR TITLE
Configurable paths based on archive contents

### DIFF
--- a/src/rms_config.erl
+++ b/src/rms_config.erl
@@ -44,7 +44,7 @@
 -define(DEFAULT_CONTAINER_PATH, "root").
 
  % The path-tail in a Riak archive, for which we search
--define(RIAK_BIN, "/riak/bin/riak").
+-define(RIAK_BIN, "riak/bin/riak").
 
 %% Helper functions.
 
@@ -129,12 +129,33 @@ container_path() ->
     find_root_path(TarTable).
 
 %% TODO Should we log something in this case?
+-spec find_root_path(list(string())) -> string().
 find_root_path([]) -> ?DEFAULT_CONTAINER_PATH;
 find_root_path([P | Paths]) ->
     case lists:suffix(?RIAK_BIN, P) of
-        true -> P;
+        true ->
+            %% Strip the known tail, leave only the prefix
+            find_prefix(P, ?RIAK_BIN);
         false -> find_root_path(Paths)
     end.
+
+-spec find_prefix(string(), string()) -> string().
+find_prefix(FullPath, Tail) ->
+    % We know that FullPath = Prefix ++ Tail
+    % How to find Prefix?
+    SplitPath = filename:split(FullPath),
+    SplitTail = filename:split(Tail),
+    % Reverse the path components
+    LiatTilps = lists:reverse(SplitTail),
+    HtapTilps = lists:reverse(SplitPath),
+    % Find the common path-tail (list-head), reverse and join
+    filename:join(lists:reverse(drop_common_prefix(LiatTilps, HtapTilps))).
+
+% Drops from A the leading elements common to A and B.
+-spec drop_common_prefix(A::list(), B::list()) -> list().
+drop_common_prefix([], Rest) -> Rest;
+drop_common_prefix([X | Rest1], [X | Rest2]) -> drop_common_prefix(Rest1, Rest2);
+drop_common_prefix(Rest, _) -> Rest.
     
 -spec artifact_urls() -> [string()].
 artifact_urls() ->

--- a/src/rms_config.erl
+++ b/src/rms_config.erl
@@ -153,7 +153,7 @@ find_prefix(FullPath, Tail) ->
 
 % Drops from A the leading elements common to A and B.
 -spec drop_common_prefix(A::list(), B::list()) -> list().
-drop_common_prefix([], Rest) -> Rest;
+drop_common_prefix([], _) -> [];
 drop_common_prefix([X | Rest1], [X | Rest2]) -> drop_common_prefix(Rest1, Rest2);
 drop_common_prefix(Rest, _) -> Rest.
     

--- a/src/rms_config.erl
+++ b/src/rms_config.erl
@@ -30,6 +30,7 @@
          artifacts/0,
          artifact_urls/0, 
          persistent_path/0,
+         container_path/0,
          framework_hostname/0]).
 
 -export([get_value/2, get_value/3]).
@@ -40,6 +41,10 @@
 -define(DEFAULT_ZK, "master.mesos:2181").
 -define(DEFAULT_CONSTRAINTS, "[]").
 -define(STATIC_ROOT, "../artifacts/").
+-define(DEFAULT_CONTAINER_PATH, "root").
+
+ % The path-tail in a Riak archive, for which we search
+-define(RIAK_BIN, "/riak/bin/riak").
 
 %% Helper functions.
 
@@ -115,6 +120,22 @@ artifacts() ->
      get_value(executor_pkg, "riak_mesos_executor.tar.gz", string)
     ].
 
+-spec container_path() -> string().
+container_path() ->
+    RiakPkg = get_value(riak_pkg, "riak.tar.gz", string),
+    ArtifactDir = "../artifacts",
+    Filename = filename:join([ArtifactDir, RiakPkg]),
+    {ok, TarTable} = erl_tar:table(Filename, [compressed]),
+    find_root_path(TarTable).
+
+%% TODO Should we log something in this case?
+find_root_path([]) -> ?DEFAULT_CONTAINER_PATH;
+find_root_path([P | Paths]) ->
+    case lists:suffix(?RIAK_BIN, P) of
+        true -> P;
+        false -> find_root_path(Paths)
+    end.
+    
 -spec artifact_urls() -> [string()].
 artifact_urls() ->
     %% TODO "static" is magic

--- a/src/rms_config.erl
+++ b/src/rms_config.erl
@@ -149,7 +149,7 @@ find_prefix(FullPath, Tail) ->
     LiatTilps = lists:reverse(SplitTail),
     HtapTilps = lists:reverse(SplitPath),
     % Find the common path-tail (list-head), reverse and join
-    filename:join(lists:reverse(drop_common_prefix(LiatTilps, HtapTilps))).
+    filename:join(lists:reverse(drop_common_prefix(HtapTilps, LiatTilps))).
 
 % Drops from A the leading elements common to A and B.
 -spec drop_common_prefix(A::list(), B::list()) -> list().

--- a/src/rms_config.erl
+++ b/src/rms_config.erl
@@ -30,7 +30,7 @@
          artifacts/0,
          artifact_urls/0, 
          persistent_path/0,
-         container_path/0,
+         riak_root_path/0,
          framework_hostname/0]).
 
 -export([get_value/2, get_value/3]).
@@ -41,7 +41,7 @@
 -define(DEFAULT_ZK, "master.mesos:2181").
 -define(DEFAULT_CONSTRAINTS, "[]").
 -define(STATIC_ROOT, "../artifacts/").
--define(DEFAULT_CONTAINER_PATH, "root").
+-define(DEFAULT_RIAK_ROOT_PATH, "root").
 
  % The path-tail in a Riak archive, for which we search
 -define(RIAK_BIN, "riak/bin/riak").
@@ -120,8 +120,8 @@ artifacts() ->
      get_value(executor_pkg, "riak_mesos_executor.tar.gz", string)
     ].
 
--spec container_path() -> string().
-container_path() ->
+-spec riak_root_path() -> string().
+riak_root_path() ->
     RiakPkg = get_value(riak_pkg, "riak.tar.gz", string),
     ArtifactDir = "../artifacts",
     Filename = filename:join([ArtifactDir, RiakPkg]),
@@ -130,7 +130,7 @@ container_path() ->
 
 %% TODO Should we log something in this case?
 -spec find_root_path(list(string())) -> string().
-find_root_path([]) -> ?DEFAULT_CONTAINER_PATH;
+find_root_path([]) -> ?DEFAULT_RIAK_ROOT_PATH;
 find_root_path([P | Paths]) ->
     case lists:suffix(?RIAK_BIN, P) of
         true ->

--- a/src/rms_node_manager.erl
+++ b/src/rms_node_manager.erl
@@ -280,7 +280,7 @@ apply_unreserved_offer(NodeKey, OfferHelper) ->
             {ok, NodeCpus} = rms_metadata:get_option(node_cpus),
             {ok, NodeMem} = rms_metadata:get_option(node_mem),
             {ok, NodeDisk} = rms_metadata:get_option(node_disk),
-            {ok, ContainerPath} = rms_metadata:get_option(persistent_path),
+            {ok, ContainerPath} = rms_metadata:get_option(container_path),
             NodeNumPorts = ?NODE_NUM_PORTS,
             Hostname = rms_offer_helper:get_hostname(OfferHelper),
             AgentIdValue = rms_offer_helper:get_agent_id_value(OfferHelper),
@@ -337,8 +337,8 @@ apply_reserved_offer(NodeKey, OfferHelper) ->
             {ok, NodeMem} = rms_metadata:get_option(node_mem),
             {ok, NodeDisk} = rms_metadata:get_option(node_disk),
             {ok, ArtifactUrls} = rms_metadata:get_option(artifact_urls),
+            {ok, ContainerPath} = rms_metadata:get_option(container_path),
             NodeNumPorts = ?NODE_NUM_PORTS,
-            ContainerPath = rms_metadata:get_option(container_path),
             UnfitForReserved =
                 rms_offer_helper:unfit_for_reserved(
                   [{cpus, NodeCpus}, {mem, NodeMem},
@@ -436,7 +436,8 @@ apply_reserved_offer(NodeKey, OfferHelper) ->
                                 {<<"HTTPPort">>,               HTTPPort},
                                 {<<"PBPort">>,                 PBPort},
                                 {<<"HandoffPort">>,            HandoffPort},
-                                {<<"DisterlPort">>,            DisterlPort}],
+                                {<<"DisterlPort">>,            DisterlPort},
+                                {<<"RootVolume">>,             list_to_binary(ContainerPath)}],
                     TaskDataBin = iolist_to_binary(mochijson2:encode(TaskData)),
 
                     % Tack a new UUID onto ExecutorId - this way we don't clash with previous instances of this same node

--- a/src/rms_node_manager.erl
+++ b/src/rms_node_manager.erl
@@ -280,7 +280,7 @@ apply_unreserved_offer(NodeKey, OfferHelper) ->
             {ok, NodeCpus} = rms_metadata:get_option(node_cpus),
             {ok, NodeMem} = rms_metadata:get_option(node_mem),
             {ok, NodeDisk} = rms_metadata:get_option(node_disk),
-            {ok, ContainerPath} = rms_metadata:get_option(container_path),
+            {ok, PersistentPath} = rms_metadata:get_option(persistent_path),
             NodeNumPorts = ?NODE_NUM_PORTS,
             Hostname = rms_offer_helper:get_hostname(OfferHelper),
             AgentIdValue = rms_offer_helper:get_agent_id_value(OfferHelper),
@@ -306,7 +306,7 @@ apply_unreserved_offer(NodeKey, OfferHelper) ->
                     OfferHelper3 =
                         rms_offer_helper:make_volume(NodeDisk, Role, Principal,
                                                      PersistenceId,
-                                                     ContainerPath,
+                                                     PersistentPath,
                                                      OfferHelper2),
 
                     Attributes =
@@ -337,7 +337,8 @@ apply_reserved_offer(NodeKey, OfferHelper) ->
             {ok, NodeMem} = rms_metadata:get_option(node_mem),
             {ok, NodeDisk} = rms_metadata:get_option(node_disk),
             {ok, ArtifactUrls} = rms_metadata:get_option(artifact_urls),
-            {ok, ContainerPath} = rms_metadata:get_option(container_path),
+            {ok, PersistentPath} = rms_metadata:get_option(persistent_path),
+            {ok, RiakRootPath} = rms_metadata:get_option(riak_root_path),
             NodeNumPorts = ?NODE_NUM_PORTS,
             UnfitForReserved =
                 rms_offer_helper:unfit_for_reserved(
@@ -362,7 +363,7 @@ apply_reserved_offer(NodeKey, OfferHelper) ->
                     OfferHelper1 =
                         rms_offer_helper:apply_reserved_resources(
                           NodeCpus, NodeMem, NodeDisk, undefined, Role,
-                          Principal, PersistenceId, ContainerPath,
+                          Principal, PersistenceId, PersistentPath,
                           OfferHelper0),
                     %% Apply unreserved resources for task.
                     OfferHelper2 =
@@ -437,7 +438,7 @@ apply_reserved_offer(NodeKey, OfferHelper) ->
                                 {<<"PBPort">>,                 PBPort},
                                 {<<"HandoffPort">>,            HandoffPort},
                                 {<<"DisterlPort">>,            DisterlPort},
-                                {<<"RootVolume">>,             list_to_binary(ContainerPath)}],
+                                {<<"RiakRootPath">>,           list_to_binary(RiakRootPath)}],
                     TaskDataBin = iolist_to_binary(mochijson2:encode(TaskData)),
 
                     % Tack a new UUID onto ExecutorId - this way we don't clash with previous instances of this same node
@@ -468,7 +469,7 @@ apply_reserved_offer(NodeKey, OfferHelper) ->
                                             DisterlPort,
                                             AgentIdValue,
                                             ExecutorIdValue,
-                                            ContainerPath),
+                                            PersistentPath),
 
                     {ok, rms_offer_helper:add_task_to_launch(TaskInfo,
                                                              OfferHelper3)};

--- a/src/rms_node_manager.erl
+++ b/src/rms_node_manager.erl
@@ -337,8 +337,8 @@ apply_reserved_offer(NodeKey, OfferHelper) ->
             {ok, NodeMem} = rms_metadata:get_option(node_mem),
             {ok, NodeDisk} = rms_metadata:get_option(node_disk),
             {ok, ArtifactUrls} = rms_metadata:get_option(artifact_urls),
-            {ok, ContainerPath} = rms_metadata:get_option(persistent_path),
             NodeNumPorts = ?NODE_NUM_PORTS,
+            ContainerPath = rms_metadata:get_option(container_path),
             UnfitForReserved =
                 rms_offer_helper:unfit_for_reserved(
                   [{cpus, NodeCpus}, {mem, NodeMem},
@@ -425,6 +425,7 @@ apply_reserved_offer(NodeKey, OfferHelper) ->
                     NodeName = iolist_to_binary([NodeKey, "@", NodeHostname]),
                     {ZkNodes, _} = rms_config:zk(),
                     Zookeepers = [list_to_binary(I) || I <- ZkNodes],
+
                     TaskData = [{<<"FullyQualifiedNodeName">>, NodeName},
                                 {<<"Host">>,                   list_to_binary(NodeHostname)},
                                 %% TODO: read list of zookeepers with rms_metadata:get_option/1

--- a/src/rms_sup.erl
+++ b/src/rms_sup.erl
@@ -113,7 +113,7 @@ init_rest() ->
 
     PersistentVolPath = rms_config:persistent_path(),
     ArtifactUrls = rms_config:artifact_urls(),
-
+    ContainerPath = rms_config:container_path(),
     Ref = riak_mesos_scheduler,
     Scheduler = rms_scheduler,
 
@@ -132,7 +132,8 @@ init_rest() ->
                         {persistent_path, PersistentVolPath},
                         {executor_cpus, ExecutorCpus},
                         {executor_mem, ExecutorMem},
-                        {artifact_urls, ArtifactUrls}],
+                        {artifact_urls, ArtifactUrls},
+                        {container_path, ContainerPath}],
 
     MasterHosts = rms_config:master_hosts(),
     ResubscribeInterval = rms_config:get_value(master_election_timeout, 60000,

--- a/src/rms_sup.erl
+++ b/src/rms_sup.erl
@@ -113,7 +113,7 @@ init_rest() ->
 
     PersistentVolPath = rms_config:persistent_path(),
     ArtifactUrls = rms_config:artifact_urls(),
-    ContainerPath = rms_config:container_path(),
+    RiakRootPath = rms_config:riak_root_path(),
     Ref = riak_mesos_scheduler,
     Scheduler = rms_scheduler,
 
@@ -133,7 +133,7 @@ init_rest() ->
                         {executor_cpus, ExecutorCpus},
                         {executor_mem, ExecutorMem},
                         {artifact_urls, ArtifactUrls},
-                        {container_path, ContainerPath}],
+                        {riak_root_path, RiakRootPath}],
 
     MasterHosts = rms_config:master_hosts(),
     ResubscribeInterval = rms_config:get_value(master_election_timeout, 60000,


### PR DESCRIPTION
These changes have the scheduler inspect the Riak archive given for the `riak/bin/riak` executable. It then uses the path this was found as `RiakRootPath` in the `TaskData` blob for the executor. Assuming there's a supporting executor on the other end, it'll use that to find the config files when configuring Riak.

See https://github.com/basho-labs/riak-mesos-executor/pull/34 for corresponding executor changes.