### PR TITLE
Reconfigure a cluster's riak version

### DIFF
--- a/src/rms_cluster.erl
+++ b/src/rms_cluster.erl
@@ -27,6 +27,7 @@
 -export([get/1,
          get/2,
          get_field_value/2,
+         set_riak_version/2,
          set_riak_config/2,
          set_advanced_config/2,
          set_generation/2,
@@ -115,6 +116,11 @@ get_field_value(Field, Key) ->
 -spec leave(pid(), rms_node:key(), list(rms_node:key())) -> ok | {error, term()}.
 leave(Pid, NodeKey, NodeKeys) ->
     gen_fsm:send_all_state_event(Pid, {leave, NodeKey, NodeKeys}).
+
+-spec set_riak_version(pid(), string()) -> ok | {error, term()}.
+set_riak_version(Pid, RiakVersion) ->
+    gen_fsm:sync_send_all_state_event(Pid, {set_riak_version, RiakVersion}).
+
 
 -spec set_riak_config(pid(), binary()) -> ok | {error, term()}.
 set_riak_config(Pid, RiakConfig) ->

--- a/src/rms_cluster.erl
+++ b/src/rms_cluster.erl
@@ -475,7 +475,7 @@ maybe_do_join(NodeKey, [ExistingNodeKey|Rest]) ->
                 {ok, [{<<"error">>,<<"not_single_node">>}]} ->
                     ok;
                 {ok, [{_,[{<<"success">>,true}]}]} ->
-                    ok;            
+                    ok;
                 {ok, Json} ->
                     lager:warning("Failed node join attempt from node ~s to node ~s. Reason: ~p", [N, E, Json]),
                     maybe_do_join(NodeKey, Rest);

--- a/src/rms_cluster_manager.erl
+++ b/src/rms_cluster_manager.erl
@@ -32,6 +32,7 @@
          get_cluster_advanced_config/1,
          add_cluster/2,
          add_cluster_with_nodes/2,
+         set_cluster_riak_version/2,
          set_cluster_riak_config/2,
          set_cluster_advanced_config/2,
          restart_cluster/1,
@@ -138,6 +139,17 @@ add_cluster_with_nodes(Cluster, Nodes) ->
             ok;
         {error, _Reason} = Error ->
             Error
+    end.
+
+
+-spec set_cluster_riak_version(rms_cluster:key(), string()) ->
+    ok | {error, term()}.
+set_cluster_riak_version(Key, RiakVersion) ->
+    case get_cluster_pid(Key) of
+        {ok, Pid} ->
+            rms_cluster:set_riak_version(Pid, RiakVersion);
+        {error, Reason} ->
+            {error, Reason}
     end.
 
 -spec set_cluster_riak_config(rms_cluster:key(), binary()) ->

--- a/src/rms_wm_helper.erl
+++ b/src/rms_wm_helper.erl
@@ -41,7 +41,7 @@
 
 -export([to_json/1, to_json/2, from_json/1, from_json/2]).
 
--define(CLUSTER_FIELDS, [key, riak_version, riak_config, advanced_config, generation]).
+-define(CLUSTER_FIELDS, [key, status, riak_version, riak_config, advanced_config, generation]).
 
 -define(CLUSTER_NODE_FIELDS, [key, status, container_path, persistence_id]).
 

--- a/src/rms_wm_resource.erl
+++ b/src/rms_wm_resource.erl
@@ -321,7 +321,7 @@ set_cluster_riak_version(ReqData) ->
         BinRiakVersion when is_binary(BinRiakVersion) ->
             Key = wrq:path_info(key, ReqData),
             RiakVersion = binary_to_list(BinRiakVersion),
-            Response = rms_cluster_manager:set_cluster_riak_version(Key, RiakVersion),
+            Response = build_response(rms_cluster_manager:set_cluster_riak_version(Key, RiakVersion)),
             {true, wrq:append_to_response_body(mochijson2:encode(Response), ReqData)}
     end.
 


### PR DESCRIPTION
Add machinery to set a cluster's configured riak version at runtime.

~~TODO~~:
 - [x] Add to HTTP API for CLI tooling